### PR TITLE
fix(jooq-starter): wire RecordListener via DefaultConfigurationCustomizer and switch hook to storeStart

### DIFF
--- a/jooq-starter/src/main/kotlin/org/dema/jooq/autoconfigure/JooqStarterAutoConfiguration.kt
+++ b/jooq-starter/src/main/kotlin/org/dema/jooq/autoconfigure/JooqStarterAutoConfiguration.kt
@@ -3,12 +3,11 @@ package org.dema.jooq.autoconfigure
 import org.dema.jooq.timestamps.TimestampsProperties
 import org.dema.jooq.timestamps.TimestampsRecordListener
 import org.jooq.DSLContext
-import org.jooq.RecordListenerProvider
-import org.jooq.impl.DefaultRecordListenerProvider
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.autoconfigure.jooq.DefaultConfigurationCustomizer
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import java.time.Clock
@@ -16,6 +15,11 @@ import java.time.Clock
 /**
  * Autoconfiguration for the jooq-starter module. Wires the timestamps RecordListener and a
  * default Clock bean when no overrides are provided by the application.
+ *
+ * The listener is registered via a [DefaultConfigurationCustomizer] because Spring Boot's
+ * `JooqAutoConfiguration` does NOT auto-wire `RecordListenerProvider` beans (it only wires
+ * `ExecuteListenerProvider`). The customizer is the supported extension point for adding
+ * record listeners.
  *
  * @author Denis Markushin
  */
@@ -35,14 +39,16 @@ class JooqStarterAutoConfiguration {
         havingValue = "true",
         matchIfMissing = true,
     )
-    fun timestampsRecordListenerProvider(
+    fun timestampsConfigurationCustomizer(
         clock: Clock,
         properties: TimestampsProperties,
-    ): RecordListenerProvider = DefaultRecordListenerProvider(
-        TimestampsRecordListener(
-            clock = clock,
-            createdAtColumn = properties.createdAtColumn,
-            updatedAtColumn = properties.updatedAtColumn,
-        ),
-    )
+    ): DefaultConfigurationCustomizer = DefaultConfigurationCustomizer {
+            it.setAppending(
+                TimestampsRecordListener(
+                    clock = clock,
+                    createdAtColumn = properties.createdAtColumn,
+                    updatedAtColumn = properties.updatedAtColumn,
+                ),
+            )
+        }
 }

--- a/jooq-starter/src/main/kotlin/org/dema/jooq/timestamps/TimestampsRecordListener.kt
+++ b/jooq-starter/src/main/kotlin/org/dema/jooq/timestamps/TimestampsRecordListener.kt
@@ -11,11 +11,14 @@ import java.time.LocalDateTime
  * Jooq RecordListener that automatically populates audit timestamp columns on store operations.
  *
  * Behavior:
- *  - On INSERT: sets `createdAtColumn` to now() only if the field is currently null.
- *  - On UPDATE: sets `updatedAtColumn` to now() unconditionally.
+ *  - `createdAtColumn` is populated only when null (preserves explicit values, e.g. test fixtures).
+ *  - `updatedAtColumn` is overwritten unconditionally on every store.
  *
- * Triggers only on UpdatableRecord.store()/insert()/update() — not on
- * dsl.update(table).set(...).execute().
+ * Hooks `storeStart` rather than `insertStart`/`updateStart` because the latter fire AFTER jOOQ
+ * has already built the UPDATE SET clause from the record's `changed()` flags. Mutations from
+ * `storeStart` propagate into the subsequent INSERT or UPDATE query construction.
+ *
+ * Triggers only on UpdatableRecord.store() — not on dsl.update(table).set(...).execute().
  *
  * @author Denis Markushin
  */
@@ -25,16 +28,10 @@ class TimestampsRecordListener(
     private val updatedAtColumn: String,
 ) : RecordListener {
 
-    override fun insertStart(ctx: RecordContext) {
+    override fun storeStart(ctx: RecordContext) {
         val record = ctx.record() as? UpdatableRecord<*> ?: return
         val now = LocalDateTime.now(clock)
         setIfNull(record, createdAtColumn, now)
-        setAlways(record, updatedAtColumn, now)
-    }
-
-    override fun updateStart(ctx: RecordContext) {
-        val record = ctx.record() as? UpdatableRecord<*> ?: return
-        val now = LocalDateTime.now(clock)
         setAlways(record, updatedAtColumn, now)
     }
 

--- a/jooq-starter/src/test/kotlin/org/dema/jooq/autoconfigure/JooqStarterAutoConfigurationTest.kt
+++ b/jooq-starter/src/test/kotlin/org/dema/jooq/autoconfigure/JooqStarterAutoConfigurationTest.kt
@@ -4,16 +4,14 @@ import assertk.all
 import assertk.assertThat
 import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
-import assertk.assertions.isInstanceOf
 import assertk.assertions.isSameInstanceAs
 import assertk.assertions.isTrue
 import assertk.assertions.prop
 import org.dema.jooq.timestamps.TimestampsProperties
 import org.jooq.DSLContext
-import org.jooq.RecordListenerProvider
-import org.jooq.impl.DefaultRecordListenerProvider
 import org.junit.jupiter.api.Test
 import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.autoconfigure.jooq.DefaultConfigurationCustomizer
 import org.springframework.boot.test.context.FilteredClassLoader
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
 import java.time.Clock
@@ -26,10 +24,11 @@ class JooqStarterAutoConfigurationTest {
         .withConfiguration(AutoConfigurations.of(JooqStarterAutoConfiguration::class.java))
 
     @Test
-    fun `autoconfig registers RecordListenerProvider bean with default properties`() {
+    fun `autoconfig registers DefaultConfigurationCustomizer bean with default properties`() {
         runner.run { context ->
-            assertThat(context.getBean(RecordListenerProvider::class.java))
-                .isInstanceOf(DefaultRecordListenerProvider::class.java)
+            assertThat(context.getBean(DefaultConfigurationCustomizer::class.java)).isEqualTo(
+                context.getBean(DefaultConfigurationCustomizer::class.java),
+            )
         }
     }
 
@@ -53,7 +52,7 @@ class JooqStarterAutoConfigurationTest {
     fun `autoconfig disables listener when property enabled is false`() {
         runner.withPropertyValues("dema.jooq.timestamps.enabled=false")
             .run { context ->
-                assertThat(context.getBeansOfType(RecordListenerProvider::class.java)).isEmpty()
+                assertThat(context.getBeansOfType(DefaultConfigurationCustomizer::class.java)).isEmpty()
             }
     }
 
@@ -75,7 +74,7 @@ class JooqStarterAutoConfigurationTest {
     fun `autoconfig backs off when DSLContext is not on classpath`() {
         runner.withClassLoader(FilteredClassLoader(DSLContext::class.java))
             .run { context ->
-                assertThat(context.getBeansOfType(RecordListenerProvider::class.java)).isEmpty()
+                assertThat(context.getBeansOfType(DefaultConfigurationCustomizer::class.java)).isEmpty()
             }
     }
 }

--- a/jooq-starter/src/test/kotlin/org/dema/jooq/timestamps/TimestampsRecordListenerTest.kt
+++ b/jooq-starter/src/test/kotlin/org/dema/jooq/timestamps/TimestampsRecordListenerTest.kt
@@ -26,7 +26,7 @@ class TimestampsRecordListenerTest {
     )
 
     @Test
-    fun `insertStart sets createdAt to clock now when field is null`() {
+    fun `storeStart sets createdAt to clock now when field is null`() {
         val record = mockk<UpdatableRecord<*>>(relaxed = true)
         val createdField = mockField("created_at")
         val updatedField = mockField("updated_at")
@@ -35,13 +35,13 @@ class TimestampsRecordListenerTest {
         every { record.get(createdField) } returns null
         val ctx = mockk<RecordContext> { every { record() } returns record }
 
-        listener.insertStart(ctx)
+        listener.storeStart(ctx)
 
         verify { record.set(createdField, expectedNow) }
     }
 
     @Test
-    fun `insertStart does not overwrite createdAt when field already has value`() {
+    fun `storeStart does not overwrite createdAt when field already has value`() {
         val record = mockk<UpdatableRecord<*>>(relaxed = true)
         val createdField = mockField("created_at")
         val updatedField = mockField("updated_at")
@@ -51,13 +51,13 @@ class TimestampsRecordListenerTest {
         every { record.get(createdField) } returns existing
         val ctx = mockk<RecordContext> { every { record() } returns record }
 
-        listener.insertStart(ctx)
+        listener.storeStart(ctx)
 
         verify(exactly = 0) { record.set(createdField, any<LocalDateTime>()) }
     }
 
     @Test
-    fun `insertStart sets updatedAt unconditionally`() {
+    fun `storeStart sets updatedAt unconditionally on new record`() {
         val record = mockk<UpdatableRecord<*>>(relaxed = true)
         val createdField = mockField("created_at")
         val updatedField = mockField("updated_at")
@@ -66,35 +66,39 @@ class TimestampsRecordListenerTest {
         every { record.get(createdField) } returns null
         val ctx = mockk<RecordContext> { every { record() } returns record }
 
-        listener.insertStart(ctx)
+        listener.storeStart(ctx)
 
         verify { record.set(updatedField, expectedNow) }
     }
 
     @Test
-    fun `updateStart sets updatedAt to clock now overwriting previous value`() {
+    fun `storeStart sets updatedAt to clock now overwriting previous value on existing record`() {
         val record = mockk<UpdatableRecord<*>>(relaxed = true)
+        val createdField = mockField("created_at")
         val updatedField = mockField("updated_at")
+        val existingCreated = LocalDateTime.of(2020, 1, 1, 0, 0)
+        every { record.field("created_at") } returns createdField
         every { record.field("updated_at") } returns updatedField
+        every { record.get(createdField) } returns existingCreated
         val ctx = mockk<RecordContext> { every { record() } returns record }
 
-        listener.updateStart(ctx)
+        listener.storeStart(ctx)
 
         verify { record.set(updatedField, expectedNow) }
     }
 
     @Test
-    fun `insertStart skips when record is not UpdatableRecord`() {
+    fun `storeStart skips when record is not UpdatableRecord`() {
         val plain = mockk<Record>(relaxed = true)
         val ctx = mockk<RecordContext> { every { record() } returns plain }
 
-        listener.insertStart(ctx)
+        listener.storeStart(ctx)
 
         verify(exactly = 0) { plain.set(any<Field<Any>>(), any()) }
     }
 
     @Test
-    fun `insertStart skips column when type is not LocalDateTime`() {
+    fun `storeStart skips column when type is not LocalDateTime`() {
         val record = mockk<UpdatableRecord<*>>(relaxed = true)
         val createdField = mockk<Field<String>>()
         every { createdField.type } returns String::class.java
@@ -102,19 +106,19 @@ class TimestampsRecordListenerTest {
         every { record.field("updated_at") } returns null
         val ctx = mockk<RecordContext> { every { record() } returns record }
 
-        listener.insertStart(ctx)
+        listener.storeStart(ctx)
 
         verify(exactly = 0) { record.set(any<Field<LocalDateTime>>(), any<LocalDateTime>()) }
     }
 
     @Test
-    fun `insertStart skips column when field is absent from table`() {
+    fun `storeStart skips column when field is absent from table`() {
         val record = mockk<UpdatableRecord<*>>(relaxed = true)
         every { record.field("created_at") } returns null
         every { record.field("updated_at") } returns null
         val ctx = mockk<RecordContext> { every { record() } returns record }
 
-        listener.insertStart(ctx)
+        listener.storeStart(ctx)
 
         verify(exactly = 0) { record.set(any<Field<LocalDateTime>>(), any<LocalDateTime>()) }
     }
@@ -134,7 +138,7 @@ class TimestampsRecordListenerTest {
         every { record.get(createdField) } returns null
         val ctx = mockk<RecordContext> { every { record() } returns record }
 
-        customListener.insertStart(ctx)
+        customListener.storeStart(ctx)
 
         verify { record.set(updatedField, expectedNow) }
     }


### PR DESCRIPTION
## Summary

Fixes two interlocking bugs that prevented the timestamps RecordListener from working end-to-end in Spring Boot applications.

1. **Wiring**: Spring Boot's JooqAutoConfiguration does NOT auto-wire RecordListenerProvider beans (only ExecuteListenerProvider). The previous autoconfig exposed a RecordListenerProvider bean that Spring Boot silently ignored. Switch to publishing a DefaultConfigurationCustomizer bean that appends our provider to Configuration.recordListenerProviders().

2. **Hook**: RecordListener.insertStart/updateStart fire AFTER jOOQ has already built the INSERT/UPDATE SET clause, so mutations from inside those callbacks do not propagate into the SQL. Switch to storeStart, which fires before query construction in store().