### PR TITLE
feat(graphql-dgs-starter): add toString to RelayPageable for meaningul log output

### DIFF
--- a/graphql-dgs-starter/src/main/kotlin/org/dema/graphql/dgs/pagination/RelayPageable.kt
+++ b/graphql-dgs-starter/src/main/kotlin/org/dema/graphql/dgs/pagination/RelayPageable.kt
@@ -30,4 +30,10 @@ class RelayPageable(
                 "Cursor size: [${values.size}] does not match orderBy fields size: [${orderByClauses.size}]"
             }
         } ?: emptyArray()
+
+    override fun toString(): String = "RelayPageable(" +
+        "first=$first, " +
+        "after=$after, " +
+        "sortingKey=$sortingKey" +
+        ")"
 }


### PR DESCRIPTION
Previously RelayPageable printed as identity hash (e.g. @35a7037) in log statements. Override toString to display first, after, and sortingKey fields.