### PR TITLE
feat(security-starter): add JWT Support

### DIFF
--- a/security-starter/README.md
+++ b/security-starter/README.md
@@ -1,18 +1,101 @@
 # Security starter
 
-Provides a basic Spring Security configuration for services.
-The module exposes an autoconfiguration with common settings for Swagger, Actuator and GraphQL endpoints.
-In non-production profiles it also enables a filter that reads user
-roles from the `X-Roles` header.
+Spring Security auto-configuration shared across services. It owns a single
+`SecurityFilterChain` with sensible defaults (CSRF disabled, stateless sessions,
+Swagger / Actuator / GraphQL / internal endpoints public, everything else
+authenticated) and offers pluggable authentication mechanisms.
+
+## What you get
+
+- **Base filter chain** (`BaseSecurityAutoConfiguration`) — CSRF off, `STATELESS`
+  sessions, `permitAll` for `/swagger-ui/**`, `/v3/api-docs/**`,
+  `/swagger-ui.html`, `/actuator/**`, `/graphql`, `/internal/**`, and
+  `authenticated` for any other request. `@EnableMethodSecurity` is on.
+- **JWT authentication** (`JwtAutoConfiguration`) — activates automatically when a
+  `JwtDecoder` is present (i.e. when the application configures
+  `spring.security.oauth2.resourceserver.jwt.*`). Extracts authorities from a
+  configurable claim and renders auth failures as JSON.
+- **X-Roles header auth** (`XRolesAutoConfiguration`) — non-production only; reads
+  roles from the `X-Roles` header for local development.
 
 ## Usage
 
-1. Add dependency:
-   ```kotlin
-   implementation("io.github.denis-markushin:security-starter:x.x.x")
-   ```
-2. Send requests with the `X-Roles` header during local development:
-   ```
-   X-Roles: admin,user
-   ```
-   The filter will populate the security context with the provided authorities.
+Add the dependency:
+```kotlin
+implementation("io.github.denis-markushin:security-starter:x.x.x")
+```
+The base chain and X-Roles filter work out of the box. No extra configuration is
+required for local development.
+
+### Enabling JWT authentication
+
+JWT auth turns on as soon as the standard resource-server decoder is configured —
+there is no custom flag. Point the resource server at your issuer:
+```yaml
+spring:
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: https://keycloak/realms/<realm>   # or jwk-set-uri / public-key-location
+```
+When a `JwtDecoder` bean exists, the starter wires `oauth2ResourceServer` with:
+
+- a converter that reads roles from the configured claim, trims them, and
+  upper-cases them into authorities;
+- a JSON authentication entry point (see below).
+
+#### Roles claim
+
+Roles are read from a single claim, flattened recursively (any string leaf under
+the claim becomes an authority). Default claim is `realm_access`, which resolves
+Keycloak's `realm_access -> { roles: [...] }` shape:
+```yaml
+dema:
+  security:
+    jwt:
+      roles-claim: realm_access   # default
+```
+
+#### Authentication entry point
+
+Authentication failures (invalid / expired bearer token) are rendered as JSON
+instead of an empty `401`:
+
+- requests whose URI ends with `/graphql` → HTTP `200` with a GraphQL-shaped error
+  body `{"errors":[{"message":"Unauthorized","extensions":{"code":"UNAUTHENTICATED"}}]}`,
+  so a federation gateway can parse the body instead of choking on an empty 401;
+- any other request → HTTP `401` with `{"message":"Unauthorized"}`.
+
+Both responses use `application/json`.
+
+### X-Roles header (local development)
+
+In non-production profiles, send roles via a header instead of a token:
+```
+X-Roles: admin,user
+```
+The filter populates the security context with the provided authorities.
+
+## Extending the chain
+
+Each authentication mechanism contributes one `HttpSecurityCustomizer` bean:
+```kotlin
+fun interface HttpSecurityCustomizer {
+    fun customize(http: HttpSecurity)
+}
+```
+`BaseSecurityAutoConfiguration` injects all `HttpSecurityCustomizer` beans and
+applies them to the shared `HttpSecurity` after the base rules and before the
+chain is built, so an implementation may use either the raw Java API or the
+Kotlin `http { }` DSL. Provide your own bean to add a custom authentication
+mechanism; the built-in `JwtAuthCustomizer` is one such implementation.
+
+To override a built-in piece, declare your own bean — the converter, the entry
+point, and the JWT customizer are all `@ConditionalOnMissingBean`.
+
+## Configuration reference
+
+| Property                     | Default        | Description                                  |
+|------------------------------|----------------|----------------------------------------------|
+| `dema.security.jwt.roles-claim` | `realm_access` | JWT claim holding user roles (flattened).    |

--- a/security-starter/README.md
+++ b/security-starter/README.md
@@ -11,6 +11,7 @@ authenticated) and offers pluggable authentication mechanisms.
   sessions, `permitAll` for `/swagger-ui/**`, `/v3/api-docs/**`,
   `/swagger-ui.html`, `/actuator/**`, `/graphql`, `/internal/**`, and
   `authenticated` for any other request. `@EnableMethodSecurity` is on.
+  Extra public paths can be added via `dema.security.permit-all` (see below).
 - **JWT authentication** (`JwtAutoConfiguration`) — activates automatically when a
   `JwtDecoder` is present (i.e. when the application configures
   `spring.security.oauth2.resourceserver.jwt.*`). Extracts authorities from a
@@ -26,6 +27,18 @@ implementation("io.github.denis-markushin:security-starter:x.x.x")
 ```
 The base chain and X-Roles filter work out of the box. No extra configuration is
 required for local development.
+
+### Extra public paths
+
+Service-specific endpoints that must stay public are declared as ant patterns;
+they are applied before the catch-all `authenticated` rule:
+```yaml
+dema:
+  security:
+    permit-all:
+      - /api/v1/provider/**
+      - /dev/sign/**
+```
 
 ### Enabling JWT authentication
 
@@ -96,6 +109,7 @@ point, and the JWT customizer are all `@ConditionalOnMissingBean`.
 
 ## Configuration reference
 
-| Property                     | Default        | Description                                  |
-|------------------------------|----------------|----------------------------------------------|
-| `dema.security.jwt.roles-claim` | `realm_access` | JWT claim holding user roles (flattened).    |
+| Property                        | Default        | Description                                          |
+|---------------------------------|----------------|------------------------------------------------------|
+| `dema.security.permit-all`      | `[]`           | Extra ant patterns served without authentication.    |
+| `dema.security.jwt.roles-claim` | `realm_access` | JWT claim holding user roles (flattened).            |

--- a/security-starter/src/main/kotlin/org/dema/security/config/BaseSecurityAutoConfiguration.kt
+++ b/security-starter/src/main/kotlin/org/dema/security/config/BaseSecurityAutoConfiguration.kt
@@ -1,6 +1,7 @@
 package org.dema.security.config
 
 import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.core.annotation.Order
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
@@ -21,6 +22,7 @@ import org.springframework.security.web.SecurityFilterChain
 @AutoConfiguration
 @EnableWebSecurity
 @EnableMethodSecurity
+@EnableConfigurationProperties(BaseSecurityProperties::class)
 class BaseSecurityAutoConfiguration {
     /**
      * Builds the default [SecurityFilterChain] applied to the application.
@@ -34,6 +36,7 @@ class BaseSecurityAutoConfiguration {
     fun defaultSecurityFilterChain(
         http: HttpSecurity,
         customizers: List<HttpSecurityCustomizer>,
+        properties: BaseSecurityProperties,
     ): SecurityFilterChain {
         http {
             csrf { disable() }
@@ -45,6 +48,7 @@ class BaseSecurityAutoConfiguration {
                 authorize("/actuator/**", permitAll)
                 authorize("/graphql", permitAll)
                 authorize("/internal/**", permitAll)
+                properties.permitAll.forEach { authorize(it, permitAll) }
                 authorize(anyRequest, authenticated)
             }
         }

--- a/security-starter/src/main/kotlin/org/dema/security/config/BaseSecurityAutoConfiguration.kt
+++ b/security-starter/src/main/kotlin/org/dema/security/config/BaseSecurityAutoConfiguration.kt
@@ -7,6 +7,7 @@ import org.springframework.security.config.annotation.method.configuration.Enabl
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.annotation.web.invoke
+import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.web.SecurityFilterChain
 
 /**
@@ -25,13 +26,18 @@ class BaseSecurityAutoConfiguration {
      * Builds the default [SecurityFilterChain] applied to the application.
      *
      * @param http the HTTP security builder
+     * @param customizers additional customizations applied after the base rules
      * @return configured security filter chain
      */
     @Bean
     @Order(0)
-    fun defaultSecurityFilterChain(http: HttpSecurity): SecurityFilterChain {
+    fun defaultSecurityFilterChain(
+        http: HttpSecurity,
+        customizers: List<HttpSecurityCustomizer>,
+    ): SecurityFilterChain {
         http {
             csrf { disable() }
+            sessionManagement { sessionCreationPolicy = SessionCreationPolicy.STATELESS }
             authorizeHttpRequests {
                 authorize("/swagger-ui/**", permitAll)
                 authorize("/v3/api-docs/**", permitAll)
@@ -42,6 +48,7 @@ class BaseSecurityAutoConfiguration {
                 authorize(anyRequest, authenticated)
             }
         }
+        customizers.forEach { it.customize(http) }
         return http.build()
     }
 }

--- a/security-starter/src/main/kotlin/org/dema/security/config/BaseSecurityProperties.kt
+++ b/security-starter/src/main/kotlin/org/dema/security/config/BaseSecurityProperties.kt
@@ -1,0 +1,15 @@
+package org.dema.security.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+/**
+ * Configuration for the shared security filter chain.
+ */
+@ConfigurationProperties("dema.security")
+data class BaseSecurityProperties(
+    /**
+     * Additional ant patterns served without authentication, applied before the
+     * catch-all `authenticated` rule. Use for service-specific public endpoints.
+     */
+    val permitAll: List<String> = emptyList(),
+)

--- a/security-starter/src/main/kotlin/org/dema/security/config/HttpSecurityCustomizer.kt
+++ b/security-starter/src/main/kotlin/org/dema/security/config/HttpSecurityCustomizer.kt
@@ -1,0 +1,16 @@
+package org.dema.security.config
+
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+
+/**
+ * Extension point for contributing security configuration to the shared
+ * [BaseSecurityAutoConfiguration] filter chain. Each authentication mechanism
+ * provides one implementation as a bean.
+ *
+ * Implementations configure the same [HttpSecurity] instance after the base
+ * rules and before the chain is built, so both the raw Java API and the Kotlin
+ * `http { }` DSL are valid here.
+ */
+fun interface HttpSecurityCustomizer {
+    fun customize(http: HttpSecurity)
+}

--- a/security-starter/src/main/kotlin/org/dema/security/config/JwtAuthCustomizer.kt
+++ b/security-starter/src/main/kotlin/org/dema/security/config/JwtAuthCustomizer.kt
@@ -1,0 +1,28 @@
+package org.dema.security.config
+
+import org.springframework.core.convert.converter.Converter
+import org.springframework.security.authentication.AbstractAuthenticationToken
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.invoke
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.web.AuthenticationEntryPoint
+
+/**
+ * Enables the OAuth2 resource server on the shared filter chain, plugging in
+ * the role-extracting converter and the JSON authentication entry point.
+ */
+class JwtAuthCustomizer(
+    private val converter: Converter<Jwt, AbstractAuthenticationToken>,
+    private val entryPoint: AuthenticationEntryPoint,
+) : HttpSecurityCustomizer {
+    override fun customize(http: HttpSecurity) {
+        http {
+            oauth2ResourceServer {
+                authenticationEntryPoint = entryPoint
+                jwt {
+                    jwtAuthenticationConverter = converter
+                }
+            }
+        }
+    }
+}

--- a/security-starter/src/main/kotlin/org/dema/security/config/JwtAutoConfiguration.kt
+++ b/security-starter/src/main/kotlin/org/dema/security/config/JwtAutoConfiguration.kt
@@ -1,0 +1,44 @@
+package org.dema.security.config
+
+import org.dema.security.jwt.JwtAuthoritiesConverter
+import org.dema.security.jwt.SecurityJwtProperties
+import org.dema.security.web.JwtAuthenticationEntryPoint
+import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.AutoConfigureAfter
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.core.convert.converter.Converter
+import org.springframework.security.authentication.AbstractAuthenticationToken
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.security.web.AuthenticationEntryPoint
+
+/**
+ * Registers JWT authentication beans when an OAuth2 resource server
+ * [JwtDecoder] is present, i.e. when the application configures
+ * `spring.security.oauth2.resourceserver.jwt.*`.
+ */
+@AutoConfiguration
+@AutoConfigureAfter(OAuth2ResourceServerAutoConfiguration::class)
+@ConditionalOnBean(JwtDecoder::class)
+@EnableConfigurationProperties(SecurityJwtProperties::class)
+class JwtAutoConfiguration {
+    @Bean
+    @ConditionalOnMissingBean
+    fun jwtAuthoritiesConverter(properties: SecurityJwtProperties): Converter<Jwt, AbstractAuthenticationToken> =
+        JwtAuthoritiesConverter(properties)
+
+    @Bean
+    @ConditionalOnMissingBean
+    fun jwtAuthenticationEntryPoint(): AuthenticationEntryPoint = JwtAuthenticationEntryPoint()
+
+    @Bean
+    @ConditionalOnMissingBean
+    fun jwtAuthCustomizer(
+        converter: Converter<Jwt, AbstractAuthenticationToken>,
+        entryPoint: AuthenticationEntryPoint,
+    ): JwtAuthCustomizer = JwtAuthCustomizer(converter, entryPoint)
+}

--- a/security-starter/src/main/kotlin/org/dema/security/jwt/JwtAuthoritiesConverter.kt
+++ b/security-starter/src/main/kotlin/org/dema/security/jwt/JwtAuthoritiesConverter.kt
@@ -1,0 +1,31 @@
+package org.dema.security.jwt
+
+import org.springframework.core.convert.converter.Converter
+import org.springframework.security.authentication.AbstractAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
+
+/**
+ * Builds an authenticated token from a JWT, extracting authorities from the
+ * configured roles claim. Roles are trimmed and upper-cased.
+ */
+class JwtAuthoritiesConverter(
+    private val properties: SecurityJwtProperties,
+) : Converter<Jwt, AbstractAuthenticationToken> {
+    override fun convert(jwt: Jwt): AbstractAuthenticationToken {
+        val authorities: List<SimpleGrantedAuthority> = jwt.claims[properties.rolesClaim]
+            .extractRoles()
+            .map(String::trim)
+            .map(String::uppercase)
+            .map(::SimpleGrantedAuthority)
+        return JwtAuthenticationToken(jwt, authorities, jwt.subject)
+    }
+
+    private fun Any?.extractRoles(): Collection<String> = when (this) {
+        is String -> listOf(this)
+        is Collection<*> -> mapNotNull { it?.toString() }
+        is Map<*, *> -> flatMap { (_, v) -> v.extractRoles() }
+        else -> emptyList()
+    }
+}

--- a/security-starter/src/main/kotlin/org/dema/security/jwt/SecurityJwtProperties.kt
+++ b/security-starter/src/main/kotlin/org/dema/security/jwt/SecurityJwtProperties.kt
@@ -1,0 +1,16 @@
+package org.dema.security.jwt
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+/**
+ * Configuration for JWT-based authority extraction.
+ */
+@ConfigurationProperties("dema.security.jwt")
+data class SecurityJwtProperties(
+    /**
+     * JWT claim name that holds user roles. Every string leaf found under the
+     * claim becomes an authority, so a nested `realm_access` -> { roles: [...] }
+     * resolves to its role list.
+     */
+    val rolesClaim: String = "realm_access",
+)

--- a/security-starter/src/main/kotlin/org/dema/security/web/JwtAuthenticationEntryPoint.kt
+++ b/security-starter/src/main/kotlin/org/dema/security/web/JwtAuthenticationEntryPoint.kt
@@ -1,0 +1,36 @@
+package org.dema.security.web
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.security.core.AuthenticationException
+import org.springframework.security.web.AuthenticationEntryPoint
+
+private const val GRAPHQL_UNAUTHORIZED =
+    """{"errors":[{"message":"Unauthorized","extensions":{"code":"UNAUTHENTICATED"}}]}"""
+private const val REST_UNAUTHORIZED = """{"message":"Unauthorized"}"""
+
+/**
+ * Renders authentication failures as JSON. GraphQL requests receive a
+ * GraphQL-shaped error with HTTP 200 so the federation gateway can parse the
+ * body; all other requests receive an HTTP 401 JSON payload.
+ */
+class JwtAuthenticationEntryPoint : AuthenticationEntryPoint {
+    override fun commence(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        authException: AuthenticationException?,
+    ) {
+        response.characterEncoding = Charsets.UTF_8.name()
+        response.setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+        if (request.requestURI.endsWith("/graphql")) {
+            response.status = HttpServletResponse.SC_OK
+            response.writer.write(GRAPHQL_UNAUTHORIZED)
+        } else {
+            response.status = HttpServletResponse.SC_UNAUTHORIZED
+            response.writer.write(REST_UNAUTHORIZED)
+        }
+        response.writer.flush()
+    }
+}

--- a/security-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/security-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,2 +1,3 @@
 org.dema.security.config.XRolesAutoConfiguration
 org.dema.security.config.BaseSecurityAutoConfiguration
+org.dema.security.config.JwtAutoConfiguration

--- a/security-starter/src/test/kotlin/org/dema/security/config/BaseSecurityAutoConfigurationTest.kt
+++ b/security-starter/src/test/kotlin/org/dema/security/config/BaseSecurityAutoConfigurationTest.kt
@@ -1,0 +1,30 @@
+package org.dema.security.config
+
+import assertk.assertThat
+import assertk.assertions.isTrue
+import org.junit.jupiter.api.Test
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner
+import org.springframework.security.web.SecurityFilterChain
+import org.springframework.web.servlet.handler.HandlerMappingIntrospector
+import java.util.concurrent.atomic.AtomicBoolean
+
+class BaseSecurityAutoConfigurationTest {
+    private val runner = WebApplicationContextRunner()
+        .withBean(
+            "mvcHandlerMappingIntrospector",
+            HandlerMappingIntrospector::class.java,
+            { HandlerMappingIntrospector() },
+        )
+        .withConfiguration(AutoConfigurations.of(BaseSecurityAutoConfiguration::class.java))
+
+    @Test
+    fun `applies registered http security customizers`() {
+        val invoked = AtomicBoolean(false)
+        runner.withBean(HttpSecurityCustomizer::class.java, { HttpSecurityCustomizer { invoked.set(true) } })
+            .run { context ->
+                context.getBean(SecurityFilterChain::class.java)
+                assertThat(invoked.get()).isTrue()
+            }
+    }
+}

--- a/security-starter/src/test/kotlin/org/dema/security/config/BaseSecurityAutoConfigurationTest.kt
+++ b/security-starter/src/test/kotlin/org/dema/security/config/BaseSecurityAutoConfigurationTest.kt
@@ -1,6 +1,8 @@
 package org.dema.security.config
 
 import assertk.assertThat
+import assertk.assertions.hasSize
+import assertk.assertions.isNotNull
 import assertk.assertions.isTrue
 import org.junit.jupiter.api.Test
 import org.springframework.boot.autoconfigure.AutoConfigurations
@@ -25,6 +27,27 @@ class BaseSecurityAutoConfigurationTest {
             .run { context ->
                 context.getBean(SecurityFilterChain::class.java)
                 assertThat(invoked.get()).isTrue()
+            }
+    }
+
+    @Test
+    fun `binds extra permit-all patterns`() {
+        runner
+            .withPropertyValues(
+                "dema.security.permit-all[0]=/api/v1/provider/**",
+                "dema.security.permit-all[1]=/dev/sign/**",
+            )
+            .run { context ->
+                assertThat(context.getBean(BaseSecurityProperties::class.java).permitAll).hasSize(2)
+            }
+    }
+
+    @Test
+    fun `builds chain with extra permit-all patterns`() {
+        runner
+            .withPropertyValues("dema.security.permit-all[0]=/dev/sign/**")
+            .run { context ->
+                assertThat(context.getBean(SecurityFilterChain::class.java)).isNotNull()
             }
     }
 }

--- a/security-starter/src/test/kotlin/org/dema/security/config/JwtAutoConfigurationTest.kt
+++ b/security-starter/src/test/kotlin/org/dema/security/config/JwtAutoConfigurationTest.kt
@@ -1,0 +1,57 @@
+package org.dema.security.config
+
+import assertk.assertThat
+import assertk.assertions.hasSize
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import assertk.assertions.isTrue
+import org.dema.security.jwt.JwtAuthoritiesConverter
+import org.dema.security.jwt.SecurityJwtProperties
+import org.dema.security.web.JwtAuthenticationEntryPoint
+import org.junit.jupiter.api.Test
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.jwt.JwtDecoder
+
+class JwtAutoConfigurationTest {
+    private val runner = ApplicationContextRunner()
+        .withConfiguration(AutoConfigurations.of(JwtAutoConfiguration::class.java))
+
+    @Test
+    fun `backs off when no JwtDecoder present`() {
+        runner.run { context ->
+            assertThat(context.getBeansOfType(JwtAuthCustomizer::class.java)).isEmpty()
+        }
+    }
+
+    @Test
+    fun `registers jwt customizer when JwtDecoder present`() {
+        runner.withBean(JwtDecoder::class.java, { JwtDecoder { _ -> error("decode not used in this test") } })
+            .run { context ->
+                assertThat(context.containsBean("jwtAuthCustomizer")).isTrue()
+            }
+    }
+
+    @Test
+    fun `honors custom roles claim property`() {
+        runner.withBean(JwtDecoder::class.java, { JwtDecoder { _ -> error("decode not used in this test") } })
+            .withPropertyValues("dema.security.jwt.roles-claim=groups")
+            .run { context ->
+                assertThat(context.getBean(SecurityJwtProperties::class.java).rolesClaim).isEqualTo("groups")
+            }
+    }
+
+    @Test
+    fun `backs off jwt customizer when user defines own`() {
+        runner
+            .withBean(JwtDecoder::class.java, { JwtDecoder { _ -> error("decode not used in this test") } })
+            .withBean(
+                JwtAuthCustomizer::class.java,
+                { JwtAuthCustomizer(JwtAuthoritiesConverter(SecurityJwtProperties()), JwtAuthenticationEntryPoint()) },
+            )
+            .run { context ->
+                assertThat(context.getBeansOfType(JwtAuthCustomizer::class.java)).hasSize(1)
+            }
+    }
+}

--- a/security-starter/src/test/kotlin/org/dema/security/config/JwtAutoConfigurationTest.kt
+++ b/security-starter/src/test/kotlin/org/dema/security/config/JwtAutoConfigurationTest.kt
@@ -11,7 +11,6 @@ import org.dema.security.web.JwtAuthenticationEntryPoint
 import org.junit.jupiter.api.Test
 import org.springframework.boot.autoconfigure.AutoConfigurations
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
-import org.springframework.security.oauth2.jwt.Jwt
 import org.springframework.security.oauth2.jwt.JwtDecoder
 
 class JwtAutoConfigurationTest {

--- a/security-starter/src/test/kotlin/org/dema/security/config/SecurityStarterIntegrationTest.kt
+++ b/security-starter/src/test/kotlin/org/dema/security/config/SecurityStarterIntegrationTest.kt
@@ -1,0 +1,42 @@
+package org.dema.security.config
+
+import assertk.assertThat
+import assertk.assertions.hasSize
+import assertk.assertions.isTrue
+import org.junit.jupiter.api.Test
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.security.web.SecurityFilterChain
+import org.springframework.web.servlet.handler.HandlerMappingIntrospector
+
+class SecurityStarterIntegrationTest {
+    private val runner = WebApplicationContextRunner()
+        .withBean(
+            "mvcHandlerMappingIntrospector",
+            HandlerMappingIntrospector::class.java,
+            { HandlerMappingIntrospector() },
+        )
+        .withBean(JwtDecoder::class.java, { JwtDecoder { _ -> error("decode not used in this test") } })
+        .withConfiguration(
+            AutoConfigurations.of(
+                BaseSecurityAutoConfiguration::class.java,
+                JwtAutoConfiguration::class.java,
+            ),
+        )
+
+    @Test
+    fun `base and jwt auto configs build a single filter chain`() {
+        runner.run { context ->
+            context.getBean(SecurityFilterChain::class.java)
+            assertThat(context.getBeansOfType(SecurityFilterChain::class.java)).hasSize(1)
+        }
+    }
+
+    @Test
+    fun `jwt customizer is registered when decoder present`() {
+        runner.run { context ->
+            assertThat(context.containsBean("jwtAuthCustomizer")).isTrue()
+        }
+    }
+}

--- a/security-starter/src/test/kotlin/org/dema/security/jwt/JwtAuthoritiesConverterTest.kt
+++ b/security-starter/src/test/kotlin/org/dema/security/jwt/JwtAuthoritiesConverterTest.kt
@@ -1,0 +1,47 @@
+package org.dema.security.jwt
+
+import assertk.assertThat
+import assertk.assertions.containsExactlyInAnyOrder
+import assertk.assertions.isEmpty
+import org.junit.jupiter.api.Test
+import org.springframework.security.oauth2.jwt.Jwt
+
+class JwtAuthoritiesConverterTest {
+    private val converter = JwtAuthoritiesConverter(SecurityJwtProperties())
+
+    private fun jwt(claims: Map<String, Any>): Jwt =
+        Jwt.withTokenValue("token")
+            .header("alg", "none")
+            .subject("user-1")
+            .claims { it.putAll(claims) }
+            .build()
+
+    @Test
+    fun `extracts and uppercases roles from realm_access`() {
+        val token = jwt(mapOf("realm_access" to mapOf("roles" to listOf("admin", "user"))))
+        val authorities = converter.convert(token).authorities.map { it.authority }
+        assertThat(authorities).containsExactlyInAnyOrder("ADMIN", "USER")
+    }
+
+    @Test
+    fun `reads roles from configured claim name`() {
+        val custom = JwtAuthoritiesConverter(SecurityJwtProperties(rolesClaim = "groups"))
+        val token = jwt(mapOf("groups" to listOf("editor")))
+        val authorities = custom.convert(token).authorities.map { it.authority }
+        assertThat(authorities).containsExactlyInAnyOrder("EDITOR")
+    }
+
+    @Test
+    fun `returns no authorities when claim absent`() {
+        val token = jwt(mapOf("other" to "x"))
+        val authorities = converter.convert(token).authorities
+        assertThat(authorities).isEmpty()
+    }
+
+    @Test
+    fun `extracts single string role`() {
+        val token = jwt(mapOf("realm_access" to "admin"))
+        val authorities = converter.convert(token).authorities.map { it.authority }
+        assertThat(authorities).containsExactlyInAnyOrder("ADMIN")
+    }
+}

--- a/security-starter/src/test/kotlin/org/dema/security/web/JwtAuthenticationEntryPointTest.kt
+++ b/security-starter/src/test/kotlin/org/dema/security/web/JwtAuthenticationEntryPointTest.kt
@@ -1,0 +1,54 @@
+package org.dema.security.web
+
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpHeaders
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+
+class JwtAuthenticationEntryPointTest {
+    private val entryPoint = JwtAuthenticationEntryPoint()
+
+    @Test
+    fun `graphql request body carries UNAUTHENTICATED code`() {
+        val request = MockHttpServletRequest().apply { requestURI = "/graphql" }
+        val response = MockHttpServletResponse()
+        entryPoint.commence(request, response, null)
+        assertThat(response.contentAsString).contains("UNAUTHENTICATED")
+    }
+
+    @Test
+    fun `graphql request stays status 200`() {
+        val request = MockHttpServletRequest().apply { requestURI = "/graphql" }
+        val response = MockHttpServletResponse()
+        entryPoint.commence(request, response, null)
+        assertThat(response.status).isEqualTo(200)
+    }
+
+    @Test
+    fun `rest request returns status 401`() {
+        val request = MockHttpServletRequest().apply { requestURI = "/api/things" }
+        val response = MockHttpServletResponse()
+        entryPoint.commence(request, response, null)
+        assertThat(response.status).isEqualTo(401)
+    }
+
+    @Test
+    fun `response declares json content type`() {
+        val request = MockHttpServletRequest().apply { requestURI = "/graphql" }
+        val response = MockHttpServletResponse()
+        JwtAuthenticationEntryPoint().commence(request, response, null)
+        assertThat(response.getHeader(HttpHeaders.CONTENT_TYPE)).isNotNull().contains("application/json")
+    }
+
+    @Test
+    fun `path merely ending in graphql is treated as rest`() {
+        val request = MockHttpServletRequest().apply { requestURI = "/api/mygraphql" }
+        val response = MockHttpServletResponse()
+        JwtAuthenticationEntryPoint().commence(request, response, null)
+        assertThat(response.status).isEqualTo(401)
+    }
+}


### PR DESCRIPTION
- adds base filter for JWT with predefined settings
- add graphql support (auth exceptions handling)
- provides permit-all consumer configuration