### PR TITLE
build(outbox-starter): add kapt for configuration processor and fix p…

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,8 +19,10 @@ configure(subprojects.filterNot { it == project(":bom") }) {
     // Spring Boot starters dependencies
     if (name.contains("-starter")) {
         apply(plugin = "org.jetbrains.kotlin.plugin.spring")
+        apply(plugin = "org.jetbrains.kotlin.kapt")
 
         dependencies {
+            "kapt"("org.springframework.boot:spring-boot-configuration-processor")
             // Test libs
             "testImplementation"("org.springframework.boot:spring-boot-starter-test") {
                 exclude(group = "org.mockito")

--- a/outbox-starter/src/main/kotlin/org/dema/outbox/OutboxEvent.kt
+++ b/outbox-starter/src/main/kotlin/org/dema/outbox/OutboxEvent.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 
 /**
  * Marker for domain payloads published through the outbox.
- * [eventType] and [aggregateType] are denormalised into table columns and
+ * [eventType] and [aggregateType] are denormalized into table columns and
  * excluded from the JSON payload.
  */
 interface OutboxEvent {

--- a/outbox-starter/src/main/kotlin/org/dema/outbox/OutboxProperties.kt
+++ b/outbox-starter/src/main/kotlin/org/dema/outbox/OutboxProperties.kt
@@ -5,17 +5,17 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 @ConfigurationProperties("dema.outbox")
 data class OutboxProperties(
     /** Kafka topic events are published to. Required. */
-    val topic: String = "",
+    var topic: String = "",
     /** Scheduler poll interval (ms). */
-    val pollIntervalMs: Long = 1000,
+    var pollIntervalMs: Long = 1000,
     /** Rows fetched per poll. */
-    val batchSize: Int = 100,
+    var batchSize: Int = 100,
     /** Event becomes dead (excluded from fetch) after this many failed sends. */
-    val maxAttempts: Int = 5,
-    val liquibase: Liquibase = Liquibase(),
+    var maxAttempts: Int = 5,
+    var liquibase: Liquibase = Liquibase(),
 ) {
     data class Liquibase(
         /** Auto-create the outbox_events table on startup. */
-        val enabled: Boolean = true,
+        var enabled: Boolean = true,
     )
 }


### PR DESCRIPTION
…roperty bindings

- Apply kotlin-kapt plugin and add spring-boot-configuration-processor dependency to enable metadata generation for @ConfigurationProperties
- Change OutboxProperties fields from val to var to allow Spring Boot property binding via setter injection
- Fix typo: \"denormalised\" → \"denormalized\" in OutboxEvent KDoc